### PR TITLE
:+1: stringオプションのデフォルト値が空文字でもエラーが出ないようにする

### DIFF
--- a/app/lib/usi/parse/option.go
+++ b/app/lib/usi/parse/option.go
@@ -154,13 +154,20 @@ func TextFromFilenameType(s string) (*engine.Text, error) {
 }
 
 func parseText(res [][]string, errMsg string) (*engine.Text, error) {
-	if len(res) == 0 || len(res[0]) < 3 {
+	if len(res) == 0 || len(res[0]) < 2 {
 		return nil, errors.New(errMsg)
+	}
+
+	// USIの仕様では、デフォルト値が空白文字の場合、<empty>を渡さなければならないが
+	// 将棋エンジンによっては空白文字のまま出力する模様
+	dflt := "" // "<empty>" の方が良いかもしれない
+	if len(res[0]) == 3 {
+		dflt = res[0][2]
 	}
 
 	return &engine.Text{
 		Name:    res[0][1],
 		Value:   res[0][2],
-		Default: res[0][2],
+		Default: dflt,
 	}, nil
 }

--- a/app/lib/usi/parse/option_test.go
+++ b/app/lib/usi/parse/option_test.go
@@ -196,14 +196,9 @@ func TestTextFromStringType(t *testing.T) {
 			},
 			nil,
 		},
-		{"option name BookFile type string",
-			nil,
-			errEmp,
-		},
-		{"option name BookFile type string public.bin",
-			nil,
-			errEmp,
-		},
+		{"option name BookFile type string default ", &engine.Text{Name: "BookFile"}, nil},
+		{"option name BookFile type string", nil, errEmp},
+		{"option name BookFile type string public.bin", nil, errEmp},
 	}
 	for _, c := range cases {
 		o, err := TextFromStringType(c.in)
@@ -234,14 +229,9 @@ func TestTextFromFilenameType(t *testing.T) {
 			},
 			nil,
 		},
-		{"option name LearningFile type filename",
-			nil,
-			errEmp,
-		},
-		{"option name LearningFile type filename <empty>",
-			nil,
-			errEmp,
-		},
+		{"option name LearningFile type filename default", &engine.Text{Name: "LearningFile"}, nil},
+		{"option name LearningFile type filename", nil, errEmp},
+		{"option name LearningFile type filename <empty>", nil, errEmp},
 	}
 	for _, c := range cases {
 		o, err := TextFromFilenameType(c.in)

--- a/app/lib/usi/parse/vars.go
+++ b/app/lib/usi/parse/vars.go
@@ -30,8 +30,8 @@ var (
 	checkRegex    = regexp.MustCompile(`^option name (.*) type check default (true|false)$`)
 	spinRegex     = regexp.MustCompile(`^option name (.*) type spin default (-?[0-9]+) min (-?[0-9]+) max (-?[0-9]+)$`)
 	selectRegex   = regexp.MustCompile(`^option name (.*) type combo default (.*?) (var .*)$`)
-	stringRegex   = regexp.MustCompile(`^option name (.*) type string default (.*)$`)
-	fileNameRegex = regexp.MustCompile(`^option name (.*) type filename default (.*)$`)
+	stringRegex   = regexp.MustCompile(`^option name (.*) type string default ?(.*?)$`)
+	fileNameRegex = regexp.MustCompile(`^option name (.*) type filename default ?(.*?)$`)
 
 	usiOptionFormat = `
 Formats


### PR DESCRIPTION
#10 